### PR TITLE
Add default.project.json to console output when default.project.json/rojo.json is changed

### DIFF
--- a/src/Rojo.ts
+++ b/src/Rojo.ts
@@ -265,7 +265,7 @@ export class Rojo extends vscode.Disposable {
   private watch (): void {
     this.watcher = fs.watch(this.configPath, () => {
       this.stop()
-      this.outputChannel.appendLine('rojo.json/default.project.json changed, reloading Rojo.')
+        this.outputChannel.appendLine('Project configuration changed, reloading Rojo.')
       this.serve()
     })
   }

--- a/src/Rojo.ts
+++ b/src/Rojo.ts
@@ -265,7 +265,7 @@ export class Rojo extends vscode.Disposable {
   private watch (): void {
     this.watcher = fs.watch(this.configPath, () => {
       this.stop()
-      this.outputChannel.appendLine('rojo.json changed, reloading Rojo.')
+      this.outputChannel.appendLine('rojo.json/default.project.json changed, reloading Rojo.')
       this.serve()
     })
   }

--- a/src/Rojo.ts
+++ b/src/Rojo.ts
@@ -265,7 +265,7 @@ export class Rojo extends vscode.Disposable {
   private watch (): void {
     this.watcher = fs.watch(this.configPath, () => {
       this.stop()
-        this.outputChannel.appendLine('Project configuration changed, reloading Rojo.')
+      this.outputChannel.appendLine('Project configuration changed, reloading Rojo.')
       this.serve()
     })
   }


### PR DESCRIPTION
Why did I add this? Since default.project.json is now included by default as of 0.5.0x, it should make sense to have it in the output when default.project.json is changed for 0.5.0x users.

I kept rojo.json in the output because there might be some 0.4.0x users who use this extension...
