### PR TITLE
configurable level file type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+# Next
+
+- Add option to change build format between binary and XML. Default is XML.
+
 # 1.12.0
 
 - Support Rojo v6 (#26)

--- a/package.json
+++ b/package.json
@@ -113,6 +113,15 @@
                     "type": "string",
                     "default": "build",
                     "description": "The output path of the build command, relative to your root folder."
+                },
+                "rojo.levelFileType": {
+                    "type": "string",
+                    "enum": [
+                        "rbxl",
+                        "rbxlx"
+                    ],
+                    "default": "rbxl",
+                    "description": "The file type rojo should save the level as."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-rojo",
   "displayName": "Rojo - Roblox Studio Sync",
   "description": "Build robust Roblox games using Rojo directly from VS Code to sync your scripts into Roblox Studio.",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "repository": "https://github.com/evaera/vscode-rojo",
   "publisher": "evaera",
   "engines": {
@@ -80,58 +80,10 @@
           "default": null,
           "description": "Whether or not Rojo will manage installing the Rojo plugin rbxmx file into the Roblox Studio plugins folder or not."
         },
-        "configuration": {
-          "title": "Rojo configuration",
-          "properties": {
-            "rojo.pluginManagement": {
-              "type": "boolean",
-              "default": null,
-              "description": "Whether or not Rojo will manage installing the Rojo plugin rbxmx file into the Roblox Studio plugins folder or not."
-            },
-            "rojo.robloxStudioPluginsPath": {
-              "type": "string",
-              "default": "",
-              "description": "The plugins for for Roblox Studio, if this extension is managing plugin installation."
-            },
-            "rojo.cargo": {
-              "type": "string",
-              "default": "cargo",
-              "description": "Name or full path `cargo` executable used to build and install Rojo from source on macOS"
-            },
-            "rojo.enableTelemetry": {
-              "type": "boolean",
-              "default": true,
-              "description": "Whether or not to send basic, anonymous usage reports to this extension's maintainer (does not gather any information about your files or game)."
-            },
-            "rojo.releaseBranch": {
-              "type": "string",
-              "enum": [
-                "0.4.x",
-                "0.5.x",
-                "0.6.x"
-              ],
-              "default": "0.5.x",
-              "description": "The release branch to install."
-            },
-            "rojo.targetVersion": {
-              "type": "string",
-              "description": "The specific target version tag to install. This setting overrides the releaseBranch setting."
-            },
-            "rojo.buildOutputPath": {
-              "type": "string",
-              "default": "build",
-              "description": "The output path of the build command, relative to your root folder."
-            },
-            "rojo.buildFileFormat": {
-              "type": "string",
-              "enum": [
-                "XML",
-                "binary"
-              ],
-              "default": "XML",
-              "description": "The file format used by the build command."
-            }
-          }
+        "rojo.robloxStudioPluginsPath": {
+          "type": "string",
+          "default": "",
+          "description": "The plugins for for Roblox Studio, if this extension is managing plugin installation."
         },
         "rojo.cargo": {
           "type": "string",
@@ -167,7 +119,7 @@
           "type": "string",
           "enum": [
             "XML",
-            "binary"
+            "Binary"
           ],
           "default": "XML",
           "description": "The file format used by the build command."

--- a/package.json
+++ b/package.json
@@ -122,14 +122,14 @@
               "default": "build",
               "description": "The output path of the build command, relative to your root folder."
             },
-            "rojo.levelFileType": {
+            "rojo.buildFileFormat": {
               "type": "string",
               "enum": [
-                "rbxl",
-                "rbxlx"
+                "XML",
+                "binary"
               ],
-              "default": "rbxl",
-              "description": "The file type rojo should save the level as."
+              "default": "XML",
+              "description": "The file format used by the build command."
             }
           }
         },
@@ -162,6 +162,15 @@
           "type": "string",
           "default": "build",
           "description": "The output path of the build command, relative to your root folder."
+        },
+        "rojo.buildFileFormat": {
+          "type": "string",
+          "enum": [
+            "XML",
+            "binary"
+          ],
+          "default": "XML",
+          "description": "The file format used by the build command."
         }
       }
     },

--- a/src/versions/V05.ts
+++ b/src/versions/V05.ts
@@ -52,8 +52,9 @@ export class V05 implements Version {
 
   async build(): Promise<void> {
     const outputConfig = getConfiguration().get("buildOutputPath") as string
+    const levelFileType = getConfiguration().get("levelFileType") as string
     const outputFile = `${outputConfig}.${
-      this.isConfigRootDataModel() ? "rbxl" : "rbxm"
+      this.isConfigRootDataModel() ? levelFileType : "rbxm"
     }`
     const outputPath = path.join(this.rojo.getWorkspacePath(), outputFile)
 

--- a/src/versions/V05.ts
+++ b/src/versions/V05.ts
@@ -53,10 +53,31 @@ export class V05 implements Version {
 
   async build(): Promise<void> {
     const outputConfig = getConfiguration().get("buildOutputPath") as string
-    const levelFileType = getConfiguration().get("levelFileType") as string
-    const outputFile = `${outputConfig}.${
-      this.isConfigRootDataModel() ? levelFileType : "rbxm"
-    }`
+    const buildFileFormat = getConfiguration().get("buildFileFormat") as string
+
+    let outputFileType: string;
+    if (this.isConfigRootDataModel()) {
+        outputFileType = "rbxmx";
+        if (buildFileFormat) {
+            if (buildFileFormat === "XML") {
+                outputFileType = "rbxmx"
+            } else if (buildFileFormat === "binary") {
+                outputFileType = "rbxm"
+            }
+        }
+    } else {
+        // Level file
+        outputFileType = "rbxlx";
+        if (buildFileFormat) {
+            if (buildFileFormat === "XML") {
+                outputFileType = "rbxlx";
+            } else if (buildFileFormat === "binary") {
+                outputFileType = "rbxl";
+            }
+        }
+    }
+
+    const outputFile = `${outputConfig}.${outputFileType}`
     const outputPath = path.join(this.rojo.getWorkspacePath(), outputFile)
 
     await fs.ensureDir(path.dirname(outputPath))

--- a/src/versions/V05.ts
+++ b/src/versions/V05.ts
@@ -55,26 +55,11 @@ export class V05 implements Version {
     const outputConfig = getConfiguration().get("buildOutputPath") as string
     const buildFileFormat = getConfiguration().get("buildFileFormat") as string
 
-    let outputFileType: string;
+    let outputFileType: string
     if (this.isConfigRootDataModel()) {
-        outputFileType = "rbxmx";
-        if (buildFileFormat) {
-            if (buildFileFormat === "XML") {
-                outputFileType = "rbxmx"
-            } else if (buildFileFormat === "binary") {
-                outputFileType = "rbxm"
-            }
-        }
+      outputFileType = buildFileFormat == "XML" ? "rbxlx" : "rbxl"
     } else {
-        // Level file
-        outputFileType = "rbxlx";
-        if (buildFileFormat) {
-            if (buildFileFormat === "XML") {
-                outputFileType = "rbxlx";
-            } else if (buildFileFormat === "binary") {
-                outputFileType = "rbxl";
-            }
-        }
+      outputFileType = buildFileFormat == "XML" ? "rbxmx" : "rbxm"
     }
 
     const outputFile = `${outputConfig}.${outputFileType}`


### PR DESCRIPTION
This PR adds a "level file type" configuration option. The selection has two fields: rbxl and rbxlx.

This should resolve #23.

Note: I was only able to test this locally by setting `preLaunchTask` to `npm: compile` in `launch.json`. I've switched it back to `npm: watch` in the PR.