### PR TITLE
Fixed bug that wouldn't shut down Rojo instances after a quit.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,6 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
+  Rojo.stopAll()    // Attempting to shut all the random instances down
   console.log('"vscode-rojo" has deactivated.')
 }
 


### PR DESCRIPTION
> First off, I'd just like to note that this is my first time submitting to an open source project. So if I am doing this wrong please tell me.

I am submitting this pull request because I was experiencing an issue on my Mac system where Rojo instances would never shut down until I manually killed them using the following commands:
```
lsof -li :34872
kill -9 PID
```

I believe I may have fixed this issue by adding what appears to be the Rojo stop function in the deactivation method.

Please let me know what you think.