### PR TITLE
Handle if Rojo server ends due to crash

### DIFF
--- a/src/Rojo.ts
+++ b/src/Rojo.ts
@@ -224,6 +224,18 @@ export class Rojo<C extends object = {}> extends vscode.Disposable {
       })
     )
 
+    this.server.on(
+      "exit",
+      // Code can possibly be "null", for example if the SIGTERM signal is sent
+      (code: number | null, _signal) => {
+        // Check if exited with a non-zero exit code (i.e. an error occured)
+        if (code && code !== 0) {
+          this.outputChannel.show()
+          statusButton.setState(ButtonState.Crashed)
+        }
+      }
+    )
+
     Rojo.stack.push(this)
 
     if (this.version.info.configChangeRestartsRojo) {

--- a/src/StatusButton.ts
+++ b/src/StatusButton.ts
@@ -4,6 +4,7 @@ import * as Strings from "./Strings"
 export enum ButtonState {
   Start,
   Running,
+  Crashed,
   Downloading,
   Installing,
   Updating,
@@ -64,6 +65,10 @@ export default class StatusButton extends vscode.Disposable {
         this.button.text = `${Strings.TEXT_RUNNING} ${version} ${
           projectFileName ? `[${projectFileName}]` : ""
         }`
+        this.button.command = "rojo.stop"
+        break
+      case ButtonState.Crashed:
+        this.button.text = Strings.TEXT_CRASHED
         this.button.command = "rojo.stop"
         break
       case ButtonState.Updating:

--- a/src/Strings.ts
+++ b/src/Strings.ts
@@ -7,6 +7,7 @@ export const TEXT_UPDATING = "$(sync) Checking for Rojo update..."
 export const TEXT_INSTALLING = "$(sync) Installing Rojo using cargo..."
 export const TEXT_START = "$(zap) Start Rojo"
 export const TEXT_RUNNING = "$(eye) Rojo"
+export const TEXT_CRASHED = "$(warning) Rojo Crashed!"
 
 export const ROJO_GIT_URL = "https://github.com/rojo-rbx/rojo.git"
 export const RELEASE_URL = "https://latest-rojo-release.eryn.workers.dev"


### PR DESCRIPTION
Small UX update to handle when Rojo unexpectedly quits due to an error.
Currently, if Rojo crashes, there is no indication of such - this can be confusing (especially for newer developers), as the button still indicates that a server is running, and you do not realise that the server has stopped until you explicitly open up the output of the extension and check.

This PR implements a new state to the button: "Crashed". If Rojo exits with a non-zero exit code, then we set the button state to "crashed". We also automatically open up the Rojo console output, so that the end user can quickly see the error that occured.

Closes #31 