### PR TITLE
Use GitHub release binaries to install on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Works on both Windows and macOS.
 ## Requirements
 
 - Windows, or
-- macOS with [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) and XCode installed
+- macOS
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -90,11 +90,6 @@
           "default": "",
           "description": "The plugins for for Roblox Studio, if this extension is managing plugin installation."
         },
-        "rojo.cargo": {
-          "type": "string",
-          "default": "cargo",
-          "description": "Name or full path `cargo` executable used to build and install Rojo from source on macOS"
-        },
         "rojo.enableTelemetry": {
           "type": "boolean",
           "default": true,

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -11,8 +11,7 @@ import {
   BINARY_NAME,
   BINARY_PATTERN,
   PLUGIN_PATTERN,
-  RELEASE_URL,
-  ROJO_GIT_URL
+  RELEASE_URL
 } from "./Strings"
 import Telemetry, { TelemetryEvent } from "./Telemetry"
 import {

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -392,6 +392,10 @@ export class Bridge extends vscode.Disposable {
           return false
         } else {
           await promisifyStream(file)
+
+          if (os.platform() !== "win32") {
+            fs.chmod(this.rojoPath, 0o755)
+          }
         }
       } catch (e) {
         console.log(e)

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -222,6 +222,19 @@ export class Bridge extends vscode.Disposable {
    * @memberof Bridge
    */
   private async installPlugin(assets: GithubAsset[]): Promise<boolean> {
+    const platform = os.platform()
+    if (platform !== "win32" && platform !== "darwin") {
+      vscode.window.showWarningMessage(
+        "Couldn't install Rojo plugin: your platform is not supported"
+      )
+      Telemetry.trackEvent(
+        TelemetryEvent.InstallationError,
+        "Platform not supported for plugin",
+        platform
+      )
+      return false
+    }
+
     const plugin = assets.find(
       file =>
         file.name.match(PLUGIN_PATTERN) != null &&
@@ -277,7 +290,7 @@ export class Bridge extends vscode.Disposable {
     switch (os.platform()) {
       case "win32":
         return /^rojo\.exe$/
-      // case "linux":
+      case "linux":
       case "darwin":
         return /^rojo$/
       default:
@@ -291,8 +304,8 @@ export class Bridge extends vscode.Disposable {
         return /^rojo(?:-|-.*-)win64.zip$/
       case "darwin":
         return /^rojo(?:-|-.*-)macos.zip$/
-      // case "linux":
-      //   return /^rojo(?:-|-.*-)linux.zip$/
+      case "linux":
+        return /^rojo(?:-|-.*-)linux.zip$/
       default:
         return undefined
     }

--- a/src/StatusButton.ts
+++ b/src/StatusButton.ts
@@ -5,7 +5,6 @@ export enum ButtonState {
   Start,
   Running,
   Downloading,
-  Installing,
   Updating,
   Hidden
 }
@@ -72,10 +71,6 @@ export default class StatusButton extends vscode.Disposable {
         break
       case ButtonState.Downloading:
         this.button.text = Strings.TEXT_DOWNLOADING
-        this.button.command = undefined
-        break
-      case ButtonState.Installing:
-        this.button.text = Strings.TEXT_INSTALLING
         this.button.command = undefined
         break
       default:

--- a/src/Strings.ts
+++ b/src/Strings.ts
@@ -4,7 +4,6 @@
 
 export const TEXT_DOWNLOADING = "$(cloud-download) Downloading Rojo..."
 export const TEXT_UPDATING = "$(sync) Checking for Rojo update..."
-export const TEXT_INSTALLING = "$(sync) Installing Rojo using cargo..."
 export const TEXT_START = "$(zap) Start Rojo"
 export const TEXT_RUNNING = "$(eye) Rojo"
 
@@ -12,7 +11,6 @@ export const ROJO_GIT_URL = "https://github.com/rojo-rbx/rojo.git"
 export const RELEASE_URL = "https://latest-rojo-release.eryn.workers.dev"
 export const BINARY_NAME = "rojo.exe"
 export const BINARY_PATTERN = /^rojo\.exe$/
-export const BINARY_ZIP_PATTERN = /^rojo(?:-|-.*-)win64.zip$/
 export const PLUGIN_PATTERN = /.+\.rbxmx?/
 
 export const VALID_SERVICES = [

--- a/src/Strings.ts
+++ b/src/Strings.ts
@@ -10,7 +10,6 @@ export const TEXT_RUNNING = "$(eye) Rojo"
 export const ROJO_GIT_URL = "https://github.com/rojo-rbx/rojo.git"
 export const RELEASE_URL = "https://latest-rojo-release.eryn.workers.dev"
 export const BINARY_NAME = "rojo.exe"
-export const BINARY_PATTERN = /^rojo\.exe$/
 export const PLUGIN_PATTERN = /.+\.rbxmx?/
 
 export const VALID_SERVICES = [

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -28,10 +28,6 @@ export function getLocalPluginPath(): string {
   return path.resolve(expandEnvironmentVars(pluginsPath))
 }
 
-export function getCargoPath(): string {
-  return expandEnvironmentVars(getConfiguration().get("cargo") as string)
-}
-
 export function getPluginIsManaged(): boolean | null {
   return getConfiguration().get("pluginManagement") as boolean | null
 }


### PR DESCRIPTION
Uses GitHub release assets for macOS install.
Should help users who don't normally use cargo/XCode to install easily.

Closes #19 

Note: I don't personally own a Mac, so I got one of my team members to test and it seemed to work OK. I would recommend a double check though beforehand, if possible.