### PR TITLE
Allow plugin paths on unsupported platforms.

### DIFF
--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -12,6 +12,7 @@ import Telemetry, { TelemetryEvent } from "./Telemetry"
 import {
   getLocalPluginPath,
   getPluginIsManaged,
+  usesCustomPluginPath,
   getReleaseBranch,
   getTargetVersion,
   promisifyStream
@@ -223,9 +224,9 @@ export class Bridge extends vscode.Disposable {
    */
   private async installPlugin(assets: GithubAsset[]): Promise<boolean> {
     const platform = os.platform()
-    if (platform !== "win32" && platform !== "darwin") {
+    if (platform !== "win32" && platform !== "darwin" && !usesCustomPluginPath()) {
       vscode.window.showWarningMessage(
-        "Couldn't install Rojo plugin: your platform is not supported"
+        "Couldn't install Rojo plugin: your platform is not supported. Try setting the Studio Plugin Path in extension settings."
       )
       Telemetry.trackEvent(
         TelemetryEvent.InstallationError,

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -28,6 +28,11 @@ export function getLocalPluginPath(): string {
   return path.resolve(expandEnvironmentVars(pluginsPath))
 }
 
+export function usesCustomPluginPath(): boolean {
+  const pluginsPath = getConfiguration().get("robloxStudioPluginsPath") as string
+  return (pluginsPath && pluginsPath.length !== 0) as boolean
+}
+
 export function getPluginIsManaged(): boolean | null {
   return getConfiguration().get("pluginManagement") as boolean | null
 }


### PR DESCRIPTION
Currently on "unsupported platforms", such as linux, the VSCode plugin cannot download the plugin. This PR makes it so if its a unsupported platform it will still try to download the platform if a custom path is specified in settings.
Fixes #51 