### PR TITLE
Improve auto-completion and validation of `*.project.json`

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,7 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
+schemas/**
+plugins/**
+.prettierrc
+*.vsix

--- a/README.md
+++ b/README.md
@@ -53,13 +53,6 @@ The release of V2 of this extension has changed how it works drastically, both i
 - Versions of Rojo before Rojo 6 are no longer supported.
 - The extension will not automatically update Rojo for you. When Rojo is installed via Aftman, you can change your installed Rojo version by editing the `aftman.toml` file in your project.
 
-New features:
-
-- Serve multiple projects at once (need to specifically set `servePort`)
-- Auto-complete for top-level services, like `ReplicatedStorage`
-  - `$className` is no longer required by the extension for these services
-- Auto-complete for `$className`, like `Part`
-
 If something about this new extension breaks your workflow, please tell us about it!
 
 - Join the [Roblox Open Source Discord Server](https://discord.gg/wH5ncNS)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ The release of V2 of this extension has changed how it works drastically, both i
 - Versions of Rojo before Rojo 6 are no longer supported.
 - The extension will not automatically update Rojo for you. When Rojo is installed via Aftman, you can change your installed Rojo version by editing the `aftman.toml` file in your project.
 
+New features:
+
+- Serve multiple projects at once (need to specifically set `servePort`)
+- Auto-complete for top-level services, like `ReplicatedStorage`
+  - `$className` is no longer required by the extension for these services
+- Auto-complete for `$className`, like `Part`
+
 If something about this new extension breaks your workflow, please tell us about it!
 
 - Join the [Roblox Open Source Discord Server](https://discord.gg/wH5ncNS)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Integrates [Rojo](https://github.com/rojo-rbx/rojo) natively with VS Code.
 ![Rojo menu](https://i.eryn.io/2222/chrome-DdVyGHdh.png)
 
 All actions are performed via the Rojo menu, as seen above. To open the Rojo menu, either:
+
 - Open the Command Pallette (`Ctrl` + `Shift` + `P`) and type "Rojo: Open menu"
 - Use the Rojo button in the bottom right corner:
 
@@ -34,7 +35,7 @@ If you are already using Foreman to manage your system Rojo, we recommend switch
 
 If you want to learn more, see the [Differences from Foreman](https://github.com/LPGhatguy/aftman#differences-from-foreman) section of the Aftman README.
 
-> ***Warning*: Stopping Rojo does not work with Foreman**
+> **_Warning_: Stopping Rojo does not work with Foreman**
 >
 > All currently-released versions of Foreman (as of v1.0.4) have a bug that makes killing the launched Rojo process leave a Rojo process running forever. There is [an open issue on the Foreman repo](https://github.com/Roblox/foreman/issues/45) for this problem, but for now you must either not use Rojo managed with Foreman, or kill the process yourself. Aftman does not have this problem.
 
@@ -53,6 +54,7 @@ The release of V2 of this extension has changed how it works drastically, both i
 - The extension will not automatically update Rojo for you. When Rojo is installed via Aftman, you can change your installed Rojo version by editing the `aftman.toml` file in your project.
 
 If something about this new extension breaks your workflow, please tell us about it!
+
 - Join the [Roblox Open Source Discord Server](https://discord.gg/wH5ncNS)
 - [Open an issue](https://github.com/rojo-rbx/vscode-rojo/issues) on the project repo
 

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "jsonValidation": [
       {
         "fileMatch": "*.project.json",
-        "url": "./schemas/project.schema.json"
+        "url": "./dist/project.schema.json"
       },
       {
         "fileMatch": "*.project.jsonc",
-        "url": "./schemas/project.schema.json"
+        "url": "./dist/project.schema.json"
       }
     ]
   },

--- a/plugins/GenerateSchemaPlugin.js
+++ b/plugins/GenerateSchemaPlugin.js
@@ -1,0 +1,83 @@
+const { readFile, writeFile } = require("fs/promises")
+const https = require('https')
+
+const API_DUMP_URL = "https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/API-Dump.json"
+
+function getAPIDump() {
+	return new Promise((resolve, reject) => {
+		const req = https.get(API_DUMP_URL, res => {
+			let raw = ""
+
+			res.on('data', chunk => {
+				raw += chunk;
+			})
+
+			res.on('end', () => {
+				const data = JSON.parse(raw);
+				resolve(data)
+			})
+
+		}).on('error', err => reject)
+
+		req.end()
+	})
+}
+
+function getServiceNames(APIDump) {
+	const services = []
+
+	for (const thisClass of APIDump.Classes) {
+		const tags = thisClass.Tags
+		if (tags && tags.includes("Service")) {
+			services.push(thisClass.Name)
+		}
+	}
+
+	return services
+}
+
+function getClassNames(APIDump) {
+	const services = []
+
+	for (const thisClass of APIDump.Classes) {
+		services.push(thisClass.Name)
+	}
+
+	return services
+}
+
+async function generateSchema() {
+	const dump = await getAPIDump()
+
+	const currentProjectSchema = JSON.parse((await readFile("schemas/project.template.schema.json")).toString())
+
+	const servicesRoot = currentProjectSchema.properties.tree.then.allOf[1].properties
+	const services = getServiceNames(dump)
+
+	for (const service of services) {
+		if (!servicesRoot[service]) {
+			servicesRoot[service] = {
+				"$ref": "#/$defs/treeService"
+			}
+		}
+	}
+
+	const classesAnyOf = currentProjectSchema["$defs"].tree.properties["$className"].anyOf
+	const classesEnum = getClassNames(dump)
+
+	classesAnyOf.push({
+		"enum": classesEnum,
+	})
+
+	const newProjectSchema = JSON.stringify(currentProjectSchema)
+	await writeFile("dist/project.schema.json", newProjectSchema)
+}
+
+module.exports = class GenerateSchemaPlugin {
+	apply(compiler) {
+		// Generate the schema by reading the template, adding dynamic content, and writing to the main file location
+		compiler.hooks.compile.tap("GenerateSchema", async () => {
+			generateSchema()
+		})
+	}
+}

--- a/schemas/project.schema.json
+++ b/schemas/project.schema.json
@@ -14,7 +14,11 @@
       "description": "The port number Rojo will use to communicate with Roblox Studio. This must be unique if you're running more than one instance of Rojo."
     },
     "tree": {
-      "$id": "/properties/tree",
+      "$ref": "#/$defs/treeNormal"
+    }
+  },
+  "$defs": {
+    "tree": {
       "type": "object",
       "properties": {
         "$className": {
@@ -33,20 +37,29 @@
             "Parent": false
           }
         }
-      },
-      "anyOf": [
+      }
+    },
+    "treeNormal": {
+      "allOf": [
         {
-          "required": ["$className"]
+          "$ref": "#/$defs/tree"
         },
         {
-          "required": ["$path"]
+          "anyOf": [
+            {
+              "required": ["$className"]
+            },
+            {
+              "required": ["$path"]
+            }
+          ],
+          "patternProperties": {
+            "^[^\\$].*$": {
+              "$ref": "#/$defs/treeNormal"
+            }
+          }
         }
-      ],
-      "patternProperties": {
-        "^[^\\$].*$": {
-          "$ref": "#/properties/tree"
-        }
-      }
+      ]
     }
   }
 }

--- a/schemas/project.schema.json
+++ b/schemas/project.schema.json
@@ -45,7 +45,55 @@
       }
     },
     "tree": {
-      "$ref": "#/$defs/treeNormal"
+      "if": {
+        "properties": {
+          "$className": {
+            "const": "DataModel"
+          }
+        },
+        "required": ["$className"]
+      },
+      "then": {
+        "allOf": [
+          {
+            "$ref": "#/$defs/tree"
+          },
+          {
+            "properties": {
+              "StarterPlayer": {
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/tree"
+                  },
+                  {
+                    "properties": {
+                      "StarterPlayerScripts": {
+                        "$ref": "#/$defs/treeService"
+                      },
+                      "StarterCharacterScripts": {
+                        "$ref": "#/$defs/treeService"
+                      }
+                    },
+                    "patternProperties": {
+                      "^[^\\$].*$": {
+                        "$ref": "#/$defs/treeNormal"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "patternProperties": {
+              "^[^\\$].*$": {
+                "$ref": "#/$defs/treeService"
+              }
+            }
+          }
+        ]
+      },
+      "else": {
+        "$ref": "#/$defs/treeNormal"
+      }
     }
   },
   "$defs": {
@@ -97,6 +145,20 @@
               "required": ["$path"]
             }
           ],
+          "patternProperties": {
+            "^[^\\$].*$": {
+              "$ref": "#/$defs/treeNormal"
+            }
+          }
+        }
+      ]
+    },
+    "treeService": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tree"
+        },
+        {
           "patternProperties": {
             "^[^\\$].*$": {
               "$ref": "#/$defs/treeNormal"

--- a/schemas/project.schema.json
+++ b/schemas/project.schema.json
@@ -28,7 +28,20 @@
           "type": "boolean"
         },
         "$path": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "optional": {
+                  "type": "string"
+                }
+              },
+              "required": ["optional"]
+            }
+          ]
         },
         "$properties": {
           "type": "object",

--- a/schemas/project.schema.json
+++ b/schemas/project.schema.json
@@ -13,6 +13,37 @@
       "title": "Serve port",
       "description": "The port number Rojo will use to communicate with Roblox Studio. This must be unique if you're running more than one instance of Rojo."
     },
+    "servePlaceIds": {
+      "type": "array",
+      "title": "Serve place IDs",
+      "description": "The set of place IDs that this project is compatible with when doing live sync. This setting is intended to help prevent syncing a Rojo project into the wrong Roblox place.",
+      "items": {
+        "type": "number"
+      }
+    },
+    "placeId": {
+      "type": "integer",
+      "title": "Place ID",
+      "description": "Sets the current place's place ID when connecting to the Rojo server from Roblox Studio."
+    },
+    "gameId": {
+      "type": "integer",
+      "title": "Game ID",
+      "description": "Sets the current place's game ID when connecting to the Rojo server from Roblox Studio."
+    },
+    "serveAddress": {
+      "type": "string",
+      "title": "Serve address",
+      "description": "This address will be used in place of the default address, as long as --address is unprovided."
+    },
+    "globIgnorePaths": {
+      "type": "array",
+      "title": "Glob ignore paths",
+      "description": "A list of globs, relative to the folder the project file is in, that match files that should be ignored if Rojo encounters them.",
+      "items": {
+        "type": "string"
+      }
+    },
     "tree": {
       "$ref": "#/$defs/treeNormal"
     }

--- a/schemas/project.template.schema.json
+++ b/schemas/project.template.schema.json
@@ -101,7 +101,11 @@
       "type": "object",
       "properties": {
         "$className": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            }
+          ]
         },
         "$ignoreUnknownInstances": {
           "type": "boolean"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,9 @@
 
 'use strict';
 
+const { writeFile, readFile } = require('fs/promises');
 const path = require('path');
+const GenerateSchemaPlugin = require('./plugins/GenerateSchemaPlugin.js');
 
 //@ts-check
 /** @typedef {import('webpack').Configuration} WebpackConfig **/
@@ -10,7 +12,7 @@ const path = require('path');
 /** @type WebpackConfig */
 const extensionConfig = {
   target: 'node', // vscode extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
-	mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
+  mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
 
   entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
   output: {
@@ -44,5 +46,9 @@ const extensionConfig = {
   infrastructureLogging: {
     level: "log", // enables logging required for problem matchers
   },
+  plugins: [
+    new GenerateSchemaPlugin()
+  ]
 };
-module.exports = [ extensionConfig ];
+
+module.exports = [extensionConfig];


### PR DESCRIPTION
This PR includes several updates:
1. Factor out the tree definition into `$defs` (to prepare for the next commits)
2. Add support for optional paths (credit to #68, can remove this commit if needed) (closes #66)
3. Allow top-level services to omit `$className`
4. Add auto-complete for services and `$className`
5. Add a "New Features" section in README.md detailing some of these changes

If you have any questions or find any issues, feel free to let me know! Thanks!