### PR TITLE
Aftman self-install errors on path with spaces

### DIFF
--- a/src/installRojo.ts
+++ b/src/installRojo.ts
@@ -166,7 +166,7 @@ export async function installRojo(folder: string) {
       await fs.promises.chmod(tempPath, 0o755)
     }
 
-    await exec(`${tempPath} self-install`)
+    await exec(`$"{tempPath}" self-install`)
 
     vscode.window.showInformationMessage(
       "Successfully installed Aftman on your system. " +


### PR DESCRIPTION
Cant self-install on path with spaces
```
Couldn't install Rojo with Aftman: Error: Command failed:
C\Users\John Doe\ AppData\Local\Temp\aftman.exe
self-install"C\Users\John is not recognized as an internal or external command, executable program, or batch file.
```

###### didn't test the extension after changes but it should work