### PR TITLE
Add project file changes in preparation for Rojo 7.4.0

### DIFF
--- a/schemas/project.template.schema.json
+++ b/schemas/project.template.schema.json
@@ -44,6 +44,11 @@
         "type": "string"
       }
     },
+    "emitLegacyScripts": {
+      "type": "boolean",
+      "title": "Emit legacy scripts",
+      "description": "Whether to emit scripts using the legacy ClassName or using RunContext."
+    },
     "tree": {
       "if": {
         "properties": {

--- a/schemas/project.template.schema.json
+++ b/schemas/project.template.schema.json
@@ -86,6 +86,25 @@
                     }
                   }
                 ]
+              },
+              "Workspace": {
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/tree"
+                  },
+                  {
+                    "properties": {
+                      "Terrain": {
+                        "$ref": "#/$defs/treeService"
+                      }
+                    },
+                    "patternProperties": {
+                      "^[^\\$].*$": {
+                        "$ref": "#/$defs/treeNormal"
+                      }
+                    }
+                  }
+                ]
               }
             },
             "patternProperties": {


### PR DESCRIPTION
In Rojo 7.4.0, whenever that releases, we have a new field called `emitLegacyScripts` in project files. Also, we've allowed Terrain to be included in a project file without a `$className` field since it's basically a service in the same vein as `StarterPlayerScripts` and `StarterCharacterScripts`.

This just adds those changes to the schema for project files.