### PR TITLE
Make aftman skip trust check when installing

### DIFF
--- a/src/installRojo.ts
+++ b/src/installRojo.ts
@@ -189,7 +189,7 @@ export async function installRojo(folder: string) {
   )
 
   if (aftmanToml) {
-    await exec("aftman install", {
+    await exec("aftman install --no-trust-check", {
       cwd: folder,
     })
 


### PR DESCRIPTION
Fixes when you have untrusted tools and try to use the extension, it errors.

![image](https://github.com/rojo-rbx/vscode-rojo/assets/80087248/3cef3f18-c741-4c96-8237-f7a3b43eb731)

Some notes are that we should be using the `--skip-untrusted` flag but it isn't implemented yet. When it does release we should be skipping untrusted tools instead of installing them.