### PR TITLE
Make Aftman skip untrusted tools

### DIFF
--- a/src/installRojo.ts
+++ b/src/installRojo.ts
@@ -189,7 +189,7 @@ export async function installRojo(folder: string) {
   )
 
   if (aftmanToml) {
-    await exec("aftman install", {
+    await exec("aftman install --skip-untrusted", {
       cwd: folder,
     })
 


### PR DESCRIPTION
When Aftman is installing tools, use `--skip-untrusted` so that if there is an untrusted tool, we skip it instead of erroring.

### Background

Aftman just released [`v0.2.8`](https://github.com/LPGhatguy/aftman/releases/tag/v0.2.8) which adds a new flag, `--skip-untrusted` that installs only trusted tools.

> If `--skip-untrusted` is given, only already trusted tools will be installed, others will be skipped and not emit any errors.
> 
> https://github.com/LPGhatguy/aftman#aftman-install

Currently, if you have an untrusted tool then the Rojo extension would just error. Instead, we should just skip the untrusted tools and let the user deal with it later.
![image](https://github.com/rojo-rbx/vscode-rojo/assets/80087248/24660391-f71c-4e19-8196-e9b09015a381)
