### PR TITLE
Fix webpack build by creating dist directory before schema generation

### DIFF
--- a/plugins/GenerateSchemaPlugin.js
+++ b/plugins/GenerateSchemaPlugin.js
@@ -1,4 +1,4 @@
-const { readFile, writeFile } = require("fs/promises")
+const { readFile, writeFile, mkdir } = require("fs/promises")
 const https = require('https')
 
 const API_DUMP_URL = "https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/API-Dump.json"
@@ -70,6 +70,7 @@ async function generateSchema() {
 	})
 
 	const newProjectSchema = JSON.stringify(currentProjectSchema)
+	await mkdir("dist", { recursive: true })
 	await writeFile("dist/project.schema.json", newProjectSchema)
 }
 


### PR DESCRIPTION
The GenerateSchemaPlugin was failing because it tried to write to dist/project.schema.json before the dist directory existed. Added mkdir call to ensure the directory is created before writing the schema file.